### PR TITLE
Remove `/var/run` volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ VOLUME /etc/corosync
 
 # Runtime info for corosync, you shouldn't need to mount this
 # (but it'll fail to start without this)
-VOLUME /var/run
+# VOLUME /var/run
 
 # The Corosync port (TCP)
 EXPOSE 5403


### PR DESCRIPTION
this fixes #3 

I'm not sure what side effect this would have on other deployment scenarios, so proceed with caution.